### PR TITLE
Strip binaries on update

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         ruby-version: ruby
         bundler-cache: true
+    - name: Install binutils-aarch64-linux-gnu
+      run: sudo apt-get install -y --no-install-recommends binutils-aarch64-linux-gnu
     - name: Run updater
       run: bundle exec ruby bin/updater
       env:

--- a/bin/updater
+++ b/bin/updater
@@ -81,12 +81,14 @@ Dir.glob("#{gitdir}/exporters/*/metadata.yml").each do |metadatafile|
 
         system(env.merge(arch => "amd64"), build, :exception => true)
         FileUtils.mv(executable, "#{dir}/#{name}_exporter_x86_64")
+        system("strip", "--strip-all", "#{dir}/#{name}_exporter_x86_64")
         git.add("#{dir}/#{name}_exporter_x86_64")
 
         puts "Build for arm64..."
 
         system(env.merge(arch => "arm64"), build, :exception => true)
         FileUtils.mv(executable, "#{dir}/#{name}_exporter_aarch64")
+        system("aarch64-linux-gnu-strip", "--strip-all", "#{dir}/#{name}_exporter_aarch64")
         git.add("#{dir}/#{name}_exporter_aarch64")
 
         puts "Update auxilliary files..."


### PR DESCRIPTION
Strip binaries on update to drastically reduce their size.

Using `GOFLAGS=-ldflags='-w -s'` doesn't work in most cases because most project's `Makefile` overrides `-ldflags`.

Packages built with `goreleaser` are generally already stripped.

Example in size reductions here:
https://github.com/Firefishy/prometheus-exporters/pulls