### PR TITLE
osm2pgsql: Use the table used by recent osm2pgsql versions

### DIFF
--- a/exporters/osm2pgsql/osm2pgsql_exporter
+++ b/exporters/osm2pgsql/osm2pgsql_exporter
@@ -36,7 +36,7 @@ server.mount_proc "/metrics" do |_request, response|
   response.body = ""
 
   begin
-    replication_delay = Time.now.utc.to_f - conn.exec("SELECT extract(epoch from importdate) FROM planet_osm_replication_status").values.first.first.to_f
+    replication_delay = Time.now.utc.to_f - conn.exec("SELECT extract(epoch from value::timestamptz) FROM osm2pgsql_properties WHERE property = 'replication_timestamp'").values.first.first.to_f
   rescue PG::UnableToSend
     conn.reset
     retry


### PR DESCRIPTION
The other table is from older versions and is no longer used.