### PR TITLE
Add connection wait time to nominatim_exporter

### DIFF
--- a/exporters/nominatim/nominatim_exporter
+++ b/exporters/nominatim/nominatim_exporter
@@ -37,6 +37,7 @@ end
 
 requests_total = {}
 request_duration_seconds = {}
+request_wait_seconds = 0.0
 
 TYPES.each do |type|
   requests_total[type] = {}
@@ -62,15 +63,17 @@ end
 
 log_thread = Thread.new do
   File::Tail::Logfile.tail(query_log) do |line|
-    if line =~ /^\[.*\] (\d+\.\d+) (\d+) (\w+) /
+    if line =~ /^\[.*\] (\d+\.\d+) (\d+) ".*" W(\d+\.\d+) /
       duration = Regexp.last_match(1).to_f
       results = Regexp.last_match(2).to_i
       type = Regexp.last_match(3)
+      wait_duration = Regexp.last_match(4).to_f
       match = results > 0 ? "yes" : "no"
 
       type = "lookup" if type == "place"
 
       requests_total[type][match] += 1
+      request_wait_seconds += wait_duration
 
       BUCKETS.each do |bucket|
         if duration <= bucket.to_f
@@ -142,6 +145,10 @@ server.mount_proc "/metrics" do |_request, response|
   response.body << "# HELP nominatim_replication_delay Replication delay in seconds\n";
   response.body << "# TYPE nominatim_replication_delay gauge\n";
   response.body << "nominatim_replication_delay #{replication_delay}\n";
+
+  response.body << "# HELP nominatim_wait_duration_seconds Time spent waiting for a DB connection during a request in seconds\n";
+  response.body << "# TYPE nominatim_wait_duration_seconds counter\n";
+  response.body << "nominatim_wait_duration_seconds #{request_wait_seconds}\n";
 end
 
 server.start


### PR DESCRIPTION
I've extended Nominatim's query log slightly to log additional metrics. It now looks like this:

```
[2025-09-13 18:44:12.796] 0.0247 1 search "q=ML10%206JU&format=json&limit=1" W0.0005 r2 f0 b0 m0.6 p0.6
[2025-09-13 18:44:12.762] 0.0574 1 reverse "format=json&addressdetails=1&lat=28.80038413839398&lon=36.291784132387214" W0.0003 r f b m p
```

The goal is to have prometheus log the average wait time, which is the number after the 'W'. I don't need this per request type because when it comes to waiting all requests are equal.

I have little experience with prometheus and no good way to test this. So feel free to throw away and do properly if it came out wrong.