### PR TITLE
Add workaround for 100MiB GitHub file size limit

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -25,6 +25,10 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: stable
+    - name: Install UPX
+      uses: crazy-max/ghaction-upx@v3
+      with:
+        install-only: true
     - name: Install binutils-aarch64-linux-gnu
       run: sudo apt-get install -y --no-install-recommends binutils-aarch64-linux-gnu
     - name: Run updater

--- a/bin/updater
+++ b/bin/updater
@@ -82,6 +82,7 @@ Dir.glob("#{gitdir}/exporters/*/metadata.yml").each do |metadatafile|
         system(env.merge(arch => "amd64"), build, :exception => true)
         FileUtils.mv(executable, "#{dir}/#{name}_exporter_x86_64")
         system("strip", "--strip-all", "#{dir}/#{name}_exporter_x86_64")
+        system("upx", "-q", "#{dir}/#{name}_exporter_x86_64") if File.size("#{dir}/#{name}_exporter_x86_64") >= 104857600 # GitHub 100 MiB file size limit
         git.add("#{dir}/#{name}_exporter_x86_64")
 
         puts "Build for arm64..."
@@ -89,6 +90,7 @@ Dir.glob("#{gitdir}/exporters/*/metadata.yml").each do |metadatafile|
         system(env.merge(arch => "arm64"), build, :exception => true)
         FileUtils.mv(executable, "#{dir}/#{name}_exporter_aarch64")
         system("aarch64-linux-gnu-strip", "--strip-all", "#{dir}/#{name}_exporter_aarch64")
+        system("upx", "-q", "#{dir}/#{name}_exporter_aarch64") if File.size("#{dir}/#{name}_exporter_aarch64") >= 104857600 # GitHub 100 MiB file size limit
         git.add("#{dir}/#{name}_exporter_aarch64")
 
         puts "Update auxilliary files..."


### PR DESCRIPTION
We will soon hit the 100MiB GitHub file size limit. Use UPX to pack exporter if needed.

`exporters/cloudwatch/cloudwatch_exporter_x86_64` is currently 98.63 MiB